### PR TITLE
Remove error when B is not a divisor of # features

### DIFF
--- a/pyHSICLasso/api.py
+++ b/pyHSICLasso/api.py
@@ -51,25 +51,20 @@ class HSICLasso(object):
 
     def regression(self, num_feat = 5, B = 0, M = 1):
 
-        if self.X_in is None or self.Y_in is None:
-            raise UnboundLocalError("Input your data")
-
         return self._run_hsic_lasso(num_feat = num_feat,
                                     y_kernel = 'Gauss',
                                     B = B, M = M)
 
     def classification(self, num_feat = 5, B = 0, M = 1):
 
-        if self.X_in is None or self.Y_in is None:
-            raise UnboundLocalError("Input your data")
-
-        self.Y_in = (np.sign(self.Y_in) + 1) / 2 + 1
-
         return self._run_hsic_lasso(num_feat = num_feat,
                                     y_kernel = 'Delta',
                                     B = B, M = M)
 
     def _run_hsic_lasso(self, y_kernel, num_feat, B, M):
+
+        if self.X_in is None or self.Y_in is None:
+            raise UnboundLocalError("Input your data")
 
         n = self.X_in.shape[1]
         B = B if B else n

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def _packages():
 
 setup(
     name="pyHSICLasso",
-    version="1.2.0",
+    version="1.2.1",
     author="Makoto Yamada",
     author_email="makoto.yamada@riken.jp",
     url="http://www.makotoyamada-ml.com/hsiclasso.html",

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -26,15 +26,6 @@ class ClassificationTest(unittest.TestCase):
         with self.assertRaises(UnboundLocalError):
             self.hsic_lasso.classification()
 
-        self.hsic_lasso.input("./tests/test_data/matlab_data.mat")
-        self.hsic_lasso.classification(5)
-        self.assertEqual(self.hsic_lasso.A, [99, 1099, 199, 1181, 112])
-
-        self.hsic_lasso.input("./tests/test_data/matlab_data.mat")
-        self.hsic_lasso.classification(10)
-        self.assertEqual(self.hsic_lasso.A, [99, 1099, 199, 1181, 112,
-                                             663, 761, 1869, 719, 977])
-
         self.hsic_lasso.input("./tests/test_data/csv_data.csv")
         self.hsic_lasso.classification(5)
         self.assertEqual(self.hsic_lasso.A, [1422, 512, 248, 1581, 764])
@@ -45,17 +36,6 @@ class ClassificationTest(unittest.TestCase):
                                              1670, 1771, 896, 779, 1472])
 
         # Blocks
-        self.hsic_lasso.input("./tests/test_data/matlab_data.mat")
-        B = int(self.hsic_lasso.X_in.shape[1]/2)
-        self.hsic_lasso.classification(5, B, 10)
-        self.assertEqual(self.hsic_lasso.A, [99, 1099, 112, 199, 761])
-
-        self.hsic_lasso.input("./tests/test_data/matlab_data.mat")
-        B = int(self.hsic_lasso.X_in.shape[1]/2)
-        self.hsic_lasso.classification(10, B, 10)
-        self.assertEqual(self.hsic_lasso.A, [99, 112, 1099, 199, 761, 
-                                             1181, 663, 977, 1112, 719])
-
         self.hsic_lasso.input("./tests/test_data/csv_data.csv")
         B = int(self.hsic_lasso.X_in.shape[1]/2)
         self.hsic_lasso.classification(5, B, 10)

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -8,6 +8,7 @@ import unittest
 
 from future import standard_library
 import numpy as np
+import warnings
 
 from pyHSICLasso import HSICLasso
 
@@ -66,12 +67,22 @@ class ClassificationTest(unittest.TestCase):
         self.assertEqual(self.hsic_lasso.A, [1422, 512, 248, 764, 1581, 
                                              1670, 1771, 896, 779, 1413])
 
-        # no error: exact divisors of n = 62
-        self.hsic_lasso.classification(5, 2)
-        self.hsic_lasso.classification(5, 31)
+        # use non-divisor as block size
+        with warnings.catch_warnings(record=True) as w:
+        
+            self.hsic_lasso.input("./tests/test_data/csv_data.csv")
+            B = int(self.hsic_lasso.X_in.shape[1]/2) - 1
+            n = self.hsic_lasso.X_in.shape[1]
+            numblocks = n / B
+            
+            self.hsic_lasso.classification(10, B, 10)
+            self.assertEqual(self.hsic_lasso.A, [1422, 248, 512, 1581, 1670, 
+                                                 764, 896, 1771, 779, 398])
 
-        with self.assertRaises(UnboundLocalError):
-            self.hsic_lasso.classification(5, 3)
+            self.assertEqual(len(w), 1)
+            self.assertEqual(w[-1].category, RuntimeWarning)
+            self.assertEqual(str(w[-1].message), "B {} must be an exact divisor of the \
+number of samples {}. Number of blocks {} will be approximated to {}.".format(B, n, numblocks, int(numblocks)))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -8,6 +8,7 @@ import unittest
 
 from future import standard_library
 import numpy as np
+import warnings
 
 from pyHSICLasso import HSICLasso
 
@@ -66,12 +67,21 @@ class RegressionTest(unittest.TestCase):
         self.assertEqual(self.hsic_lasso.A, [1422, 512, 248, 764, 1581, 
                                              1670, 1771, 896, 779, 1413])
 
-        # no error: exact divisors of n = 62
-        self.hsic_lasso.regression(5, 2)
-        self.hsic_lasso.regression(5, 31)
-
-        with self.assertRaises(UnboundLocalError):
-            self.hsic_lasso.regression(5, 3)
+        # use non-divisor as block size
+        with warnings.catch_warnings(record=True) as w:
+        
+            self.hsic_lasso.input("./tests/test_data/csv_data.csv")
+            B = int(self.hsic_lasso.X_in.shape[1]/2) - 1
+            n = self.hsic_lasso.X_in.shape[1]
+            numblocks = n / B
+            
+            self.hsic_lasso.regression(10, B, 10)
+            self.assertEqual(self.hsic_lasso.A, [1422, 248, 512, 1581, 1670, 
+                                                 764, 896, 1771, 779, 398])
+            self.assertEqual(len(w), 1)
+            self.assertEqual(w[-1].category, RuntimeWarning)
+            self.assertEqual(str(w[-1].message), "B {} must be an exact divisor of the \
+number of samples {}. Number of blocks {} will be approximated to {}.".format(B, n, numblocks, int(numblocks)))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -35,15 +35,6 @@ class RegressionTest(unittest.TestCase):
         self.assertEqual(self.hsic_lasso.A, [1099, 99, 199, 1299, 1477,
                                              1405, 1073, 299, 1596, 358])
 
-        self.hsic_lasso.input("./tests/test_data/csv_data.csv")
-        self.hsic_lasso.regression(5)
-        self.assertEqual(self.hsic_lasso.A, [1422, 512, 248, 1581, 764])
-
-        self.hsic_lasso.input("./tests/test_data/csv_data.csv")
-        self.hsic_lasso.regression(10)
-        self.assertEqual(self.hsic_lasso.A, [1422, 512, 248, 1581, 764,
-                                             1670, 1771, 896, 779, 1472])
-
         # Blocks
         self.hsic_lasso.input("./tests/test_data/matlab_data.mat")
         B = int(self.hsic_lasso.X_in.shape[1]/2)
@@ -55,17 +46,6 @@ class RegressionTest(unittest.TestCase):
         self.hsic_lasso.regression(10, B, 10)
         self.assertEqual(self.hsic_lasso.A, [1099, 99, 199, 1477, 299, 
                                              1405, 1073, 1299, 1596, 358])
-
-        self.hsic_lasso.input("./tests/test_data/csv_data.csv")
-        B = int(self.hsic_lasso.X_in.shape[1]/2)
-        self.hsic_lasso.regression(5, B, 10)
-        self.assertEqual(self.hsic_lasso.A, [1422, 512, 248, 764, 1581])
-
-        self.hsic_lasso.input("./tests/test_data/csv_data.csv")
-        B = int(self.hsic_lasso.X_in.shape[1]/2)
-        self.hsic_lasso.regression(10, B, 10)
-        self.assertEqual(self.hsic_lasso.A, [1422, 512, 248, 764, 1581, 
-                                             1670, 1771, 896, 779, 1413])
 
         # use non-divisor as block size
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
I replaced the error by a warning that # blocks = int(n/B). In this way, the user doesn't have to manually discard n % B samples.