### PR TITLE
Use float32

### DIFF
--- a/pyHSICLasso/hsic_lasso.py
+++ b/pyHSICLasso/hsic_lasso.py
@@ -18,8 +18,8 @@ standard_library.install_aliases()
 
 def compute_input_matrix(X_in, feature_idx, B, n, discarded, perms, x_kernel):
 
-    H = np.eye(B) - 1 / B * np.ones(B)
-    X = np.zeros((n * B * perms, 1))
+    H = np.eye(B, dtype=np.float32) - 1 / B * np.ones(B, dtype=np.float32)
+    X = np.zeros((n * B * perms, 1), dtype=np.float32)
 
     st = 0
     ed = B ** 2
@@ -67,17 +67,17 @@ def hsic_lasso(X_in, Y_in, y_kernel, x_kernel='Gauss', n_jobs=-1, discarded=0, B
     dy = Y_in.shape[0]
 
     # Centering matrix
-    H = np.eye(B) - 1 / B * np.ones(B)
-    lf = np.zeros((n * B * perms, 1))
+    H = np.eye(B, dtype=np.float32) - 1 / B * np.ones(B, dtype=np.float32)
+    lf = np.zeros((n * B * perms, 1), dtype=np.float32)
     index = np.arange(n)
     st = 0
     ed = B**2
 
     # Normalize data
     if x_kernel == 'Gauss':
-        X_in = X_in / (X_in.std(1)[:, None] + 10e-20)
+        X_in = (X_in / (X_in.std(1)[:, None] + 10e-20)).astype(np.float32)
     if y_kernel == "Gauss":
-        Y_in = Y_in / (Y_in.std(1)[:, None] + 10e-20)
+        Y_in = (Y_in / (Y_in.std(1)[:, None] + 10e-20)).astype(np.float32)
 
     # Compute y kernel matrix
     for p in range(perms):

--- a/pyHSICLasso/nlars.py
+++ b/pyHSICLasso/nlars.py
@@ -43,7 +43,7 @@ def nlars(X, X_ty, num_feat, max_neighbors):
     A = []
     A_neighbors = []
     A_neighbors_score = []
-    beta = np.zeros((d, 1))
+    beta = np.zeros((d, 1), dtype=np.float32)
     path = lil_matrix((d, 4 * d))
     lam = np.zeros((1, 4 * d))
 
@@ -63,7 +63,7 @@ def nlars(X, X_ty, num_feat, max_neighbors):
 
     k = 0
     while sum(c[A]) / len(A) >= 1e-9 and len(A) < num_feat + 1:
-        s = np.ones((len(A), 1))
+        s = np.ones((len(A), 1), dtype=np.float32)
         w = np.linalg.solve(np.dot(X[:, A].transpose(), X[:, A]), s)
         XtXw = np.dot(X.transpose(), np.dot(X[:, A], w))
 


### PR DESCRIPTION
In pyHSICLasso, it needs huge memory space, we decided to use float32 instead of float64

Thanks to this modification, we can make (almost) 2x faster computation with 1/2 memory size.

